### PR TITLE
Add Slack threaded replies and reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Notable changes between versions.
 
 ## Latest
 
-* Add Slack notifications of node lifecycle events
-  * Add `-webhook` flag to set the WebhookURL
+* Add Slack threading and reactions ([#7](https://github.com/poseidon/scuttle/pull/7))
+  * Add `-channel-id` flag to set a channel
+  * Add `-token` flag to set a Slack token
+* Add Slack notifications for lifecycle events ([#6](https://github.com/poseidon/scuttle/pull/6))
+  * Add `-webhook` flag for basic Slack notifications
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -89,16 +89,18 @@ systemd:
 
 Configure via flags.
 
-| flag       | description  | default      |
-|------------|--------------|--------------|
-| -platform  | Platform to poll for termination notices | none |
-| -webhook   | Slack Webhook URL      | ""   |
-| -uncordon  | Uncordon node on start | true |
-| -drain     | Drain node on stop     | true |
-| -delete    | Delete node on stop    | true |
-| -log-level | Logger level | info |
-| -version   | Show version | NA   |
-| -help      | Show help    | NA   |
+| flag        | description  | default      |
+|-------------|--------------|--------------|
+| -platform   | Platform to poll for termination notices | none |
+| -channel-id | Slack Channel ID       | ""   |
+| -token      | Slack Bot Token        | ""   |
+| -webhook    | Slack Webhook URL      | ""   |
+| -uncordon   | Uncordon node on start | true |
+| -drain      | Drain node on stop     | true |
+| -delete     | Delete node on stop    | true |
+| -log-level  | Logger level | info |
+| -version    | Show version | NA   |
+| -help       | Show help    | NA   |
 
 Other values are set via environment variables.
 
@@ -113,6 +115,30 @@ Other values are set via environment variables.
 
 * [AWS Spot Termination Notifications](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html)
 * [Azure Spot Termination Notifications](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification#get-terminate-notifications)
+
+### Slack
+
+`scuttle` integrates with Slack to post shutdown lifecycle events. Stay informed about spot terminations, shutdowns, drains, deletions.
+
+* Create a [Slack App](https://api.slack.com/apps)
+
+A token mode can post messages, thread replies, and add reactions.
+
+* Grant bot token scopes `chat:write` and `reactions:write` to a channel via "OAuth & Permissions"
+* Get the bot token
+* Invite the app to a channel (`/invite @mybot`) and note the Channel ID
+
+```
+scuttle -channel-id C0FAKEFAKE -token bot-token
+```
+
+<img src="https://storage.googleapis.com/poseidon/scuttle-slack.png">
+
+A webhook mode is available if you only have a Slack Webhook URL. However, it cannot thread replies or add reactions.
+
+```
+scuttle -webhook https://hooks.slack.com/...
+```
 
 ## Development
 

--- a/cmd/scuttle/main.go
+++ b/cmd/scuttle/main.go
@@ -28,6 +28,8 @@ var (
 
 func main() {
 	flags := struct {
+		channel  string
+		token    string
 		webhook  string
 		platform string
 		uncordon bool
@@ -38,12 +40,17 @@ func main() {
 		help     bool
 	}{}
 
-	flag.StringVar(&flags.webhook, "webhook", "", "Slack Webhook URL (e.g. https://hooks.slack.com...)")
 	flag.StringVar(&flags.platform, "platform", "none", "Set platform (none, aws, azure) to poll termination notices")
 	flag.BoolVar(&flags.uncordon, "uncordon", true, "Enabling uncordoning node on start")
 	flag.BoolVar(&flags.drain, "drain", true, "Enabling draining node on stop")
 	flag.BoolVar(&flags.delete, "delete", true, "Enable deleting node on stop")
 	flag.StringVar(&flags.logLevel, "log-level", "info", "Set the logging level")
+
+	// Slack
+	flag.StringVar(&flags.channel, "channel-id", "", "Slack Channel ID (e.g. C0FAKEFAKE)")
+	flag.StringVar(&flags.token, "token", "", "Slack App token")
+	flag.StringVar(&flags.webhook, "webhook", "", "Slack Webhook URL (e.g. https://hooks.slack.com...)")
+
 	// subcommands
 	flag.BoolVar(&flags.version, "version", false, "Print version and exit")
 	flag.BoolVar(&flags.help, "help", false, "Print usage and exit")
@@ -87,6 +94,8 @@ func main() {
 	// Termination watcher
 	scuttle, err := sctl.New(&sctl.Config{
 		Logger:         log,
+		Channel:        flags.channel,
+		Token:          flags.token,
 		Webhook:        flags.webhook,
 		Platform:       flags.platform,
 		ShouldUncordon: flags.uncordon,

--- a/internal/slack.go
+++ b/internal/slack.go
@@ -7,7 +7,10 @@
 package scuttle
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/slack-go/slack"
 )
@@ -22,24 +25,83 @@ const (
 	Delete     Notification = "delete"
 )
 
-func (w *Scuttle) notifySlack(action Notification, node string) {
-	msg := &slack.WebhookMessage{}
+// notifySlack posts a Slack message (and reaction) and returns the message
+// timestamp for threading subsequent replies.
+// - Slack client mode posts a Slack message or reply (if thread set) and
+// reaction
+// - Slack webhook mode just posts a simple message only
+func (w *Scuttle) notifySlack(action Notification, node string, thread string) string {
+	var text, reaction, color string
 
 	switch action {
 	case Uncordon:
-		msg.Text = fmt.Sprintf(":white_check_mark: Uncordon node `%s`", node)
+		color = "good"
+		text = fmt.Sprintf(":hatched_chick: Uncordon node `%s`", node)
 	case TermNotice:
-		msg.Text = fmt.Sprintf(":stopwatch: Detected spot termination notice for `%s`", node)
+		color = "warning"
+		text = fmt.Sprintf(":stopwatch: Detected spot termination notice for `%s`", node)
 	case Shutdown:
-		msg.Text = fmt.Sprintf(":octagonal_sign: Detected shutdown of `%s`", node)
+		color = "warning"
+		text = fmt.Sprintf(":warning: Detected shutdown of `%s`", node)
 	case Drain:
-		msg.Text = fmt.Sprintf(":droplet: Draining node `%s`", node)
+		color = "warning"
+		text = fmt.Sprintf(":droplet: Draining node `%s`", node)
+		reaction = "droplet"
 	case Delete:
-		msg.Text = fmt.Sprintf(":headstone: Deleting node `%s`", node)
+		color = "warning"
+		text = fmt.Sprintf(":headstone: Deleting node `%s`", node)
+		reaction = "headstone"
 	}
 
-	err := slack.PostWebhook(w.config.Webhook, msg)
-	if err != nil {
-		w.log.Errorf("error notifying Slack webhook url: %v", err)
+	now := time.Now().Format(time.StampMilli)
+	attachment := slack.Attachment{
+		Color:  color,
+		Text:   text,
+		Footer: now,
+		Ts:     json.Number(strconv.FormatInt(time.Now().Unix(), 10)),
 	}
+
+	// Slack App token mode (richer)
+	if w.slack != nil {
+		if reaction != "" {
+			msgRef := slack.NewRefToMessage(w.config.Channel, thread)
+			if err := w.slack.AddReaction(reaction, msgRef); err != nil {
+				w.log.Errorf("error posting Slack reaction: %v", err)
+			}
+		}
+
+		opts := []slack.MsgOption{
+			//slack.MsgOptionText(text, true),
+			slack.MsgOptionAttachments(attachment),
+		}
+		if thread != "" {
+			opts = append(opts, slack.MsgOptionTS(thread))
+		}
+
+		_, stamp, err := w.slack.PostMessage(
+			w.config.Channel,
+			opts...,
+		)
+		if err != nil {
+			w.log.Errorf("error posting Slack message: %v", err)
+		}
+
+		return stamp
+	}
+
+	// Slack App Webhook mode
+	if w.config.Webhook != "" {
+		msg := &slack.WebhookMessage{
+			Attachments: []slack.Attachment{
+				attachment,
+			},
+		}
+		err := slack.PostWebhook(w.config.Webhook, msg)
+		if err != nil {
+			w.log.Errorf("error sending Slack Webhook: %v", err)
+		}
+	}
+
+	// only client mode supports threading
+	return ""
 }


### PR DESCRIPTION
* Creating a Slack Client with a token, an app can thread messages and create reactions to reduce clutter
* Continue to support basic WebhookURL mode too

![scuttle-slack](https://user-images.githubusercontent.com/2253428/201994686-2e365618-fe13-4590-8de9-54f622818cee.png)
