### PR TITLE
Add the AWS CLI to the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes between versions.
 
 ## Latest
 
+* Change base image from alpine to fedora
+  * Add AWS CLI to allow kubeconfig's that exec `aws`
+  * The AWS CLI v2 has troublesome dynamic linking
 * Allow the node name to be set directly ([#8](https://github.com/poseidon/scuttle/pull/8))
   * Add `-node` flag to set the Kubernetes node name
   * Default to using the `HOSTNAME` environment variable

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,15 @@ FROM docker.io/golang:1.19.3 AS builder
 COPY . src
 RUN cd src && make build
 
-FROM docker.io/alpine:3.16.3
+FROM docker.io/fedora:37
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
-RUN apk --no-cache --update add ca-certificates
+# AWS CLI v2 is an ugly pile of Python with dynamic linking to specific
+# shared objects they zip up. And the zip doesn't even have a checksum
+#
+# Added for a customer using kubeconfig that exec's the aws cli
+# https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
+RUN dnf install -y curl zip && \
+  curl -L https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.8.13.zip -o awscliv2.zip && \
+  unzip awscliv2.zip && ./aws/install
 COPY --from=builder /go/src/bin/scuttle /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/scuttle"]


### PR DESCRIPTION
* Change base image from alpine to fedora
* Add the AWS CLI to allow kubeconfig's that exec aws
* AWS CLI v2 is a pile of Python with dynamic linking to specific shared objects Amazon zips up. No checksum. Alpine isn't supported

Note: This is for a customer use case, revert when the need disappears