### PR TITLE
Change tests to use shared GitHub Workflow from poseidon/.github

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,16 +8,10 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 1
 - package-ecosystem: gomod
   directory: "/"
   schedule:
     interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 2
   ignore:
     - dependency-name: "k8s.io/api"
     - dependency-name: "k8s.io/apimachinery"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,25 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
 jobs:
-  build:
-    name: go
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.18', '1.19']
-    steps:
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{matrix.go}}
-
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: test
-        run: make
+  go:
+    uses: poseidon/.github/.github/workflows/golang-library.yaml@main


### PR DESCRIPTION
* Centrally managed Go test workflow across Poseidon repos