### PR TITLE
Migrate multi-arch image builds to GitHub Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,15 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  go:
+    uses: poseidon/.github/.github/workflows/golang-library.yaml@main
+  multiarch:
+    uses: poseidon/fleetlock/.github/workflows/multiarch.yaml@main
+    secrets:
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,0 @@
-name: test
-on:
-  push:
-jobs:
-  go:
-    uses: poseidon/.github/.github/workflows/golang-library.yaml@main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scuttle
 [![GoDoc](https://pkg.go.dev/badge/github.com/poseidon/scuttle.svg)](https://pkg.go.dev/github.com/poseidon/scuttle)
 [![Quay](https://img.shields.io/badge/container-quay-green)](https://quay.io/repository/poseidon/scuttle)
-[![Workflow](https://github.com/poseidon/scuttle/actions/workflows/test.yaml/badge.svg)](https://github.com/poseidon/scuttle/actions/workflows/test.yaml?query=branch%3Amain)
+[![Workflow](https://github.com/poseidon/scuttle/actions/workflows/build.yaml/badge.svg)](https://github.com/poseidon/scuttle/actions/workflows/build.yaml?query=branch%3Amain)
 [![Sponsors](https://img.shields.io/github/sponsors/poseidon?logo=github)](https://github.com/sponsors/poseidon)
 [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@poseidon)
 


### PR DESCRIPTION
* Migrate from the internal Drone server using a GitHub Workflow to perform the multi-arch container image build
* Use self-hosted GitHub runners on ARM64 to perform the ARM64 build step faster that QEMU/KVM emulation
* Mandate approval for all workflow runs from outside contributors since the builds use push credentials and partially run internally