### PR TITLE
Add support for Google chat (webhook only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Configure via flags.
 | -delete     | Delete node on stop    | true |
 | -channel-id | Slack Channel ID       | ""   |
 | -token      | Slack Bot Token        | ""   |
-| -webhook    | Slack Webhook URL      | ""   |
+| -webhook    | Slack or google Webhook URL      | ""   |
 | -log-level  | Logger level | info |
 | -version    | Show version | NA   |
 | -help       | Show help    | NA   |
@@ -138,6 +138,14 @@ A webhook mode is available if you only have a Slack Webhook URL. However, it ca
 
 ```
 scuttle -webhook https://hooks.slack.com/...
+```
+
+### Google chat
+
+Supports posting messages to Google chat spaces, using Google webhook URL. It cannot thread replies or add reactions.
+
+```
+scuttle -webhook "https://chat.googleapis.com/v1/spaces/..."
 ```
 
 ## Development

--- a/cmd/scuttle/main.go
+++ b/cmd/scuttle/main.go
@@ -51,7 +51,7 @@ func main() {
 	// Slack
 	flag.StringVar(&flags.channel, "channel-id", "", "Slack Channel ID (e.g. C0FAKEFAKE)")
 	flag.StringVar(&flags.token, "token", "", "Slack App token")
-	flag.StringVar(&flags.webhook, "webhook", "", "Slack Webhook URL (e.g. https://hooks.slack.com...)")
+	flag.StringVar(&flags.webhook, "webhook", "", "Slack or Google Webhook URL (e.g. \"https://hooks.slack.com\" or \"https://chat.googleapis.com/v1/spaces/\")")
 
 	// subcommands
 	flag.BoolVar(&flags.version, "version", false, "Print version and exit")
@@ -104,6 +104,7 @@ func main() {
 		// Slack
 		Channel: flags.channel,
 		Token:   flags.token,
+		// Slack or gChat
 		Webhook: flags.webhook,
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	go.seankhliao.com/gchat v0.0.0-20230625190431-824613c32ec3 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.2
 require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.13.0
+	go.seankhliao.com/gchat v0.0.0-20230625190431-824613c32ec3
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1
@@ -33,7 +34,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.seankhliao.com/gchat v0.0.0-20230625190431-824613c32ec3 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.seankhliao.com/gchat v0.0.0-20230625190431-824613c32ec3 h1:cSUOX/9VAmSXKx/iyrRxzukTujPblfnZ6G/qGF7e1dM=
+go.seankhliao.com/gchat v0.0.0-20230625190431-824613c32ec3/go.mod h1:vCYRjn0feopqYyxZMcbsmgCjkjVaYLltYX5OrjqE87A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/gchat.go
+++ b/internal/gchat.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Poseidon Labs
+// Copyright (C) 2022 Dalton Hubble
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+package scuttle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.seankhliao.com/gchat"
+)
+
+// notifyGchat posts a message to google spaces message with a webhook.
+func (w *Scuttle) notifyGchat(action Notification) string {
+	var text string
+
+	switch action {
+	case Uncordon:
+		text = fmt.Sprintf("🐣 Uncordon node %s", w.hostname)
+	case TermNotice:
+		text = fmt.Sprintf("⏱️ Detected spot termination notice for %s", w.hostname)
+	case Shutdown:
+		text = fmt.Sprintf("⚠️ Detected shutdown of %s", w.hostname)
+	case Drain:
+		text = fmt.Sprintf("💧 Draining node %s", w.hostname)
+	case Delete:
+		text = fmt.Sprintf("🪦 Deleting node %s", w.hostname)
+	default:
+		text = fmt.Sprintf("🛑 %s", action)
+	}
+
+	now := time.Now().Format(time.StampMilli)
+
+	var msg = fmt.Sprintf("`%s` `%s`", now, text)
+
+	attachment := &gchat.WebhookPayload{
+		Text: msg,
+	}
+
+	if attachment != nil {
+		err := w.gchat.Post(context.Background(), *attachment)
+		if err != nil {
+			w.log.Warn("WebhookClient: Unable to send - `%s`", err)
+		}
+	}
+
+	return ""
+}

--- a/internal/gchat.go
+++ b/internal/gchat.go
@@ -41,11 +41,9 @@ func (w *Scuttle) notifyGchat(action Notification) string {
 		Text: msg,
 	}
 
-	if attachment != nil {
-		err := w.gchat.Post(context.Background(), *attachment)
-		if err != nil {
-			w.log.Warn("WebhookClient: Unable to send - `%s`", err)
-		}
+	err := w.gchat.Post(context.Background(), *attachment)
+	if err != nil {
+		w.log.Errorf("WebhookClient: Unable to send - %s", err)
 	}
 
 	return ""

--- a/internal/notify.go
+++ b/internal/notify.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 Poseidon Labs
+// Copyright (C) 2022 Dalton Hubble
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package scuttle
+
+type Notification string
+
+const (
+	Uncordon   Notification = "uncordon"
+	TermNotice Notification = "term-notice"
+	Shutdown   Notification = "shutdown"
+	Drain      Notification = "drain"
+	Delete     Notification = "delete"
+)
+
+func ErrorNotification(err error) Notification {
+	return Notification(err.Error())
+}
+
+func (w *Scuttle) notify(action Notification, thread string) string {
+
+	if w.gchat != nil {
+		w.notifyGchat(action)
+	} else {
+		w.notifySlack(action, w.lastThread)
+	}
+
+	return ""
+}

--- a/internal/slack.go
+++ b/internal/slack.go
@@ -7,42 +7,13 @@
 package scuttle
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/slack-go/slack"
-	"go.seankhliao.com/gchat"
 )
-
-type Notification string
-
-const (
-	Uncordon   Notification = "uncordon"
-	TermNotice Notification = "term-notice"
-	Shutdown   Notification = "shutdown"
-	Drain      Notification = "drain"
-	Delete     Notification = "delete"
-)
-
-func ErrorNotification(err error) Notification {
-	return Notification(err.Error())
-}
-
-// gchat
-func gchatReport(client *gchat.WebhookClient, obj string) {
-	// if strings.Contains(obj, "ERROR") {
-	// 	return fmt.Sprintf("WebhookClient: Unable to send - %s'", obj)
-	// }
-	err := client.Post(context.Background(), gchat.WebhookPayload{
-		Text: obj,
-	})
-	if err != nil {
-		fmt.Sprintf("WebhookClient: Unable to send - %s'", err)
-	}
-}
 
 // notifySlack posts a Slack message (and reaction) and returns the message
 // timestamp for threading subsequent replies.
@@ -55,24 +26,24 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 	switch action {
 	case Uncordon:
 		color = "good"
-		text = fmt.Sprintf("🐣 Uncordon node `%s`", w.hostname)
+		text = fmt.Sprintf(":hatched_chick: Uncordon node `%s`", w.hostname)
 	case TermNotice:
 		color = "warning"
-		text = fmt.Sprintf("⏱️ Detected spot termination notice for `%s`", w.hostname)
+		text = fmt.Sprintf(":stopwatch: Detected spot termination notice for `%s`", w.hostname)
 	case Shutdown:
 		color = "warning"
-		text = fmt.Sprintf("⚠️ Detected shutdown of `%s`", w.hostname)
+		text = fmt.Sprintf(":warning: Detected shutdown of `%s`", w.hostname)
 	case Drain:
 		color = "warning"
-		text = fmt.Sprintf("💧 Draining node `%s`", w.hostname)
+		text = fmt.Sprintf(":droplet: Draining node `%s`", w.hostname)
 		reaction = "droplet"
 	case Delete:
 		color = "warning"
-		text = fmt.Sprintf("🪦 Deleting node `%s`", w.hostname)
+		text = fmt.Sprintf(":headstone: Deleting node `%s`", w.hostname)
 		reaction = "headstone"
 	default:
 		color = "danger"
-		text = fmt.Sprintf("‼️ %s ‼️", action)
+		text = string(action)
 		reaction = "red_circle"
 	}
 
@@ -85,36 +56,34 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 	}
 
 	// Slack App token mode (richer)
-	if w.config.Webhook == "" {
-		if w.slack != nil {
-			if reaction != "" {
-				msgRef := slack.NewRefToMessage(w.config.Channel, thread)
-				if err := w.slack.AddReaction(reaction, msgRef); err != nil {
-					w.log.Errorf("error posting Slack reaction: %v", err)
-				}
+	if w.slack != nil {
+		if reaction != "" {
+			msgRef := slack.NewRefToMessage(w.config.Channel, thread)
+			if err := w.slack.AddReaction(reaction, msgRef); err != nil {
+				w.log.Errorf("error posting Slack reaction: %v", err)
 			}
-
-			opts := []slack.MsgOption{
-				slack.MsgOptionAttachments(attachment),
-			}
-			if thread != "" {
-				opts = append(opts, slack.MsgOptionTS(thread))
-			}
-
-			_, stamp, err := w.slack.PostMessage(
-				w.config.Channel,
-				opts...,
-			)
-			if err != nil {
-				w.log.Errorf("error posting Slack message: %v", err)
-			}
-
-			return stamp
 		}
+
+		opts := []slack.MsgOption{
+			slack.MsgOptionAttachments(attachment),
+		}
+		if thread != "" {
+			opts = append(opts, slack.MsgOptionTS(thread))
+		}
+
+		_, stamp, err := w.slack.PostMessage(
+			w.config.Channel,
+			opts...,
+		)
+		if err != nil {
+			w.log.Errorf("error posting Slack message: %v", err)
+		}
+
+		return stamp
 	}
 
 	// Slack App Webhook mode
-	if w.config.Webhook == "slack" {
+	if w.config.Webhook != "" {
 		msg := &slack.WebhookMessage{
 			Attachments: []slack.Attachment{
 				attachment,
@@ -123,27 +92,6 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 		err := slack.PostWebhook(w.config.Webhook, msg)
 		if err != nil {
 			w.log.Errorf("error sending Slack Webhook: %v", err)
-		}
-	}
-
-	// Google Chat Webhook mode
-	var chat *gchat.WebhookClient
-
-	if w.config.Webhook != "" {
-		var gchatEndpoint = w.config.Webhook
-		fmt.Sprintf(w.config.Webhook)
-
-		if gchatEndpoint != "" {
-			chat = &gchat.WebhookClient{
-				//Client:   &http.Client,
-				Endpoint: gchatEndpoint,
-			}
-		}
-
-		msg := attachment.Text
-
-		if chat != nil {
-			gchatReport(chat, msg)
 		}
 	}
 

--- a/internal/slack.go
+++ b/internal/slack.go
@@ -7,12 +7,14 @@
 package scuttle
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/slack-go/slack"
+	"go.seankhliao.com/gchat"
 )
 
 type Notification string
@@ -29,6 +31,19 @@ func ErrorNotification(err error) Notification {
 	return Notification(err.Error())
 }
 
+// gchat
+func gchatReport(client *gchat.WebhookClient, obj string) {
+	// if strings.Contains(obj, "ERROR") {
+	// 	return fmt.Sprintf("WebhookClient: Unable to send - %s'", obj)
+	// }
+	err := client.Post(context.Background(), gchat.WebhookPayload{
+		Text: obj,
+	})
+	if err != nil {
+		fmt.Sprintf("WebhookClient: Unable to send - %s'", err)
+	}
+}
+
 // notifySlack posts a Slack message (and reaction) and returns the message
 // timestamp for threading subsequent replies.
 // - Slack client mode posts a Slack message or reply (if thread set) and
@@ -40,24 +55,24 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 	switch action {
 	case Uncordon:
 		color = "good"
-		text = fmt.Sprintf(":hatched_chick: Uncordon node `%s`", w.hostname)
+		text = fmt.Sprintf("🐣 Uncordon node `%s`", w.hostname)
 	case TermNotice:
 		color = "warning"
-		text = fmt.Sprintf(":stopwatch: Detected spot termination notice for `%s`", w.hostname)
+		text = fmt.Sprintf("⏱️ Detected spot termination notice for `%s`", w.hostname)
 	case Shutdown:
 		color = "warning"
-		text = fmt.Sprintf(":warning: Detected shutdown of `%s`", w.hostname)
+		text = fmt.Sprintf("⚠️ Detected shutdown of `%s`", w.hostname)
 	case Drain:
 		color = "warning"
-		text = fmt.Sprintf(":droplet: Draining node `%s`", w.hostname)
+		text = fmt.Sprintf("💧 Draining node `%s`", w.hostname)
 		reaction = "droplet"
 	case Delete:
 		color = "warning"
-		text = fmt.Sprintf(":headstone: Deleting node `%s`", w.hostname)
+		text = fmt.Sprintf("🪦 Deleting node `%s`", w.hostname)
 		reaction = "headstone"
 	default:
 		color = "danger"
-		text = string(action)
+		text = fmt.Sprintf("‼️ %s ‼️", action)
 		reaction = "red_circle"
 	}
 
@@ -70,34 +85,36 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 	}
 
 	// Slack App token mode (richer)
-	if w.slack != nil {
-		if reaction != "" {
-			msgRef := slack.NewRefToMessage(w.config.Channel, thread)
-			if err := w.slack.AddReaction(reaction, msgRef); err != nil {
-				w.log.Errorf("error posting Slack reaction: %v", err)
+	if w.config.Webhook == "" {
+		if w.slack != nil {
+			if reaction != "" {
+				msgRef := slack.NewRefToMessage(w.config.Channel, thread)
+				if err := w.slack.AddReaction(reaction, msgRef); err != nil {
+					w.log.Errorf("error posting Slack reaction: %v", err)
+				}
 			}
-		}
 
-		opts := []slack.MsgOption{
-			slack.MsgOptionAttachments(attachment),
-		}
-		if thread != "" {
-			opts = append(opts, slack.MsgOptionTS(thread))
-		}
+			opts := []slack.MsgOption{
+				slack.MsgOptionAttachments(attachment),
+			}
+			if thread != "" {
+				opts = append(opts, slack.MsgOptionTS(thread))
+			}
 
-		_, stamp, err := w.slack.PostMessage(
-			w.config.Channel,
-			opts...,
-		)
-		if err != nil {
-			w.log.Errorf("error posting Slack message: %v", err)
-		}
+			_, stamp, err := w.slack.PostMessage(
+				w.config.Channel,
+				opts...,
+			)
+			if err != nil {
+				w.log.Errorf("error posting Slack message: %v", err)
+			}
 
-		return stamp
+			return stamp
+		}
 	}
 
 	// Slack App Webhook mode
-	if w.config.Webhook != "" {
+	if w.config.Webhook == "slack" {
 		msg := &slack.WebhookMessage{
 			Attachments: []slack.Attachment{
 				attachment,
@@ -106,6 +123,27 @@ func (w *Scuttle) notifySlack(action Notification, thread string) string {
 		err := slack.PostWebhook(w.config.Webhook, msg)
 		if err != nil {
 			w.log.Errorf("error sending Slack Webhook: %v", err)
+		}
+	}
+
+	// Google Chat Webhook mode
+	var chat *gchat.WebhookClient
+
+	if w.config.Webhook != "" {
+		var gchatEndpoint = w.config.Webhook
+		fmt.Sprintf(w.config.Webhook)
+
+		if gchatEndpoint != "" {
+			chat = &gchat.WebhookClient{
+				//Client:   &http.Client,
+				Endpoint: gchatEndpoint,
+			}
+		}
+
+		msg := attachment.Text
+
+		if chat != nil {
+			gchatReport(chat, msg)
 		}
 	}
 


### PR DESCRIPTION
Hi, couldnt find any contribution instructions for your project and this is my first contrib back upstream. 

Our team is currently stuck using Google services, especially Google Chat. I didnt want to have a slack only as a proxy and therefore I have extended your code to support posting messages to Google Chat Spaces via webhook using a simple wrapper (https://pkg.go.dev/go.seankhliao.com/gchat) package.

I couldnt test the reactions in the slack thread, but google chat webhook, slack webhook and slack client seems to work:

![Screenshot from 2024-06-07 10-22-50](https://github.com/poseidon/scuttle/assets/7339809/c1db5239-1beb-4cc8-bd79-5cc3ed6312d7)
![Screenshot from 2024-06-07 10-22-21](https://github.com/poseidon/scuttle/assets/7339809/9fa9c940-9a82-4c69-898a-6b06ea6ecde6)
