### PR TITLE
Fallback to lowercase hostnames for nodeName

### DIFF
--- a/cmd/scuttle/main.go
+++ b/cmd/scuttle/main.go
@@ -41,7 +41,7 @@ func main() {
 		help     bool
 	}{}
 
-	flag.StringVar(&flags.nodeName, "node", "", "Kubernetes node name (defaults to $HOSTNAME)")
+	flag.StringVar(&flags.nodeName, "node", "", "Kubernetes node name (defaults to lowercase $HOSTNAME)")
 	flag.StringVar(&flags.platform, "platform", "none", "Set platform (none, aws, azure) to poll termination notices")
 	flag.BoolVar(&flags.uncordon, "uncordon", true, "Enabling uncordoning node on start")
 	flag.BoolVar(&flags.drain, "drain", true, "Enabling draining node on stop")

--- a/internal/scuttle.go
+++ b/internal/scuttle.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -59,8 +60,8 @@ func New(config *Config) (*Scuttle, error) {
 
 	hostname := config.NodeName
 	if hostname == "" {
-		// fallback to HOSTNAME to identify Kubelet node
-		hostname = os.Getenv("HOSTNAME")
+		// fallback to lowercase HOSTNAME, like Kubelet does
+		hostname = strings.ToLower(os.Getenv("HOSTNAME"))
 	}
 
 	// Kubernetes client from kubeconfig or service account (in-cluster)


### PR DESCRIPTION
* On Azure, VMSS hostnames often have auto-generated suffixes that use capital letters. Kubelet assigns node names by detecting the hostname and converting to lowercase. We should do the same in scuttle
* Change `nodeName` to default to the _lowercase_ of $HOSTNAME